### PR TITLE
Changed price_changes to JSON reducing the amount of work on XML and make it work

### DIFF
--- a/app/code/community/Bubble/Api/Helper/Catalog/Product.php
+++ b/app/code/community/Bubble/Api/Helper/Catalog/Product.php
@@ -1,5 +1,4 @@
 <?php
-
 class Bubble_Api_Helper_Catalog_Product extends Mage_Core_Helper_Abstract
 {
     const CATEGORIES_SEPARATOR_PATH_XML = 'bubble_api/config/categories_separator';
@@ -17,14 +16,12 @@ class Bubble_Api_Helper_Catalog_Product extends Mage_Core_Helper_Abstract
                 ->addFieldToFilter('sku', array('in' => (array) $simpleSkus))
                 ->addFieldToFilter('type_id', Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)
                 ->getAllIds();
-
             $oldProductIds = Mage::getModel('catalog/product_type_configurable')->setProduct($product)->getUsedProductCollection()
                 ->addAttributeToSelect('*')
                 ->addFilterByRequiredOptions()
                 ->getAllIds();
 
             $usedProductIds = array_diff($newProductIds, $oldProductIds);
-
             if (!empty($usedProductIds)) {
                 if ($product->isConfigurable()) {
                     $this->_initConfigurableAttributesData($product, $usedProductIds, $priceChanges, $configurableAttributes);
@@ -115,12 +112,11 @@ class Bubble_Api_Helper_Catalog_Product extends Mage_Core_Helper_Abstract
         if (!$mainProduct->isConfigurable() || empty($simpleProductIds)) {
             return $this;
         }
-
+        $priceChanges = (array) $priceChanges;
         $mainProduct->setConfigurableProductsData(array_flip($simpleProductIds));
         $productType = $mainProduct->getTypeInstance(true);
         $productType->setProduct($mainProduct);
         $attributesData = $productType->getConfigurableAttributesAsArray();
-
         if (empty($attributesData)) {
             // Auto generation if configurable product has no attribute
             $attributeIds = array();
@@ -134,7 +130,7 @@ class Bubble_Api_Helper_Catalog_Product extends Mage_Core_Helper_Abstract
         }
         if (!empty($configurableAttributes)){
             foreach ($attributesData as $idx => $val) {
-                if (!in_array($val['attribute_id'], $configurableAttributes)) {
+                if (!in_array($val['attribute_id'], $configurableAttributes) && !in_array($val['attribute_code'], $configurableAttributes)) {
                     unset($attributesData[$idx]);
                 }
             }
@@ -157,6 +153,7 @@ class Bubble_Api_Helper_Catalog_Product extends Mage_Core_Helper_Abstract
                             ->getAttribute($attribute['attribute_code'])
                             ->getSource()
                             ->getOptionText($optionId);
+                        $priceChanges[$attributeCode] = (array)$priceChanges[$attributeCode];
                         if (isset($priceChanges[$attributeCode][$optionText])) {
                             if (false !== strpos($priceChanges[$attributeCode][$optionText], '%')) {
                                 $isPercent = 1;

--- a/app/code/community/Bubble/Api/Model/Catalog/Product/Api.php
+++ b/app/code/community/Bubble/Api/Model/Catalog/Product/Api.php
@@ -1,5 +1,4 @@
 <?php
-
 class Bubble_Api_Model_Catalog_Product_Api extends Mage_Catalog_Model_Product_Api
 {
     public function create($type, $set, $sku, $productData, $store = null)
@@ -47,7 +46,7 @@ class Bubble_Api_Model_Catalog_Product_Api extends Mage_Catalog_Model_Product_Ap
 
         if (isset($productData['associated_skus'])) {
             $simpleSkus = $productData['associated_skus'];
-            $priceChanges = isset($productData['price_changes']) ? $productData['price_changes'] : array();
+            $priceChanges = isset($productData['price_changes']) ? json_decode($productData['price_changes']) : array();
             $configurableAttributes = isset($productData['configurable_attributes']) ? $productData['configurable_attributes'] : array();
             Mage::helper('bubble_api/catalog_product')->associateProducts($product, $simpleSkus, $priceChanges, $configurableAttributes);
         }

--- a/app/code/community/Bubble/Api/Model/Catalog/Product/Api/V2.php
+++ b/app/code/community/Bubble/Api/Model/Catalog/Product/Api/V2.php
@@ -1,5 +1,4 @@
 <?php
-
 class Bubble_Api_Model_Catalog_Product_Api_V2 extends Mage_Catalog_Model_Product_Api_V2
 {
     public function create($type, $set, $sku, $productData, $store = null)
@@ -15,7 +14,6 @@ class Bubble_Api_Model_Catalog_Product_Api_V2 extends Mage_Catalog_Model_Product
     protected function _prepareDataForSave($product, $productData)
     {
         /* @var $product Mage_Catalog_Model_Product */
-
         if (property_exists($productData, 'categories')) {
             $categoryIds = Mage::helper('bubble_api/catalog_product')
                 ->getCategoryIdsByNames((array) $productData->categories);
@@ -71,6 +69,7 @@ class Bubble_Api_Model_Catalog_Product_Api_V2 extends Mage_Catalog_Model_Product
             $simpleSkus = (array) $productData->associated_skus;
             $priceChanges = array();
             if (property_exists($productData, 'price_changes')) {
+                $productData->price_changes = json_decode($productData->price_changes);
                 if (key($productData->price_changes) === 0) {
                     $priceChanges = $productData->price_changes[0];
                 } else {

--- a/app/code/community/Bubble/Api/etc/wsdl.xml
+++ b/app/code/community/Bubble/Api/etc/wsdl.xml
@@ -10,7 +10,7 @@
                 <all>
                     <element name="associated_skus" type="typens:ArrayOfString" minOccurs="0"/>
                     <element name="configurable_attributes" type="typens:ArrayOfString" minOccurs="0"/>
-                    <element name="price_changes" type="typens:associativeArray" minOccurs="0" />
+                    <element name="price_changes" type="xsd:string" minOccurs="0" />
                 </all>
             </complexType>
         </schema>

--- a/app/code/community/Bubble/Api/etc/wsi.xml
+++ b/app/code/community/Bubble/Api/etc/wsi.xml
@@ -23,7 +23,7 @@
                 <xsd:sequence>
                     <xsd:element name="associated_skus" type="typens:ArrayOfString" minOccurs="0" />
                     <xsd:element name="configurable_attributes" type="typens:ArrayOfString" minOccurs="0" />
-                    <xsd:element name="price_changes" type="typens:complexMultiArray" minOccurs="0" />
+                    <xsd:element name="price_changes" type="xsd:string" minOccurs="0" />
                 </xsd:sequence>
             </xsd:complexType>
         </xsd:schema>


### PR DESCRIPTION
The format to send price_changes in JSON is the following:

price_changes = [
    {'color': {'blue': 99, /*'color': price, */}},
    {'size': {'XGG': 1000, 'GG': 500, 'G': 100, '42': 9}},
    // {'another-attribute-code': {'some-value': some_price}}
]

Also, I fixed some crashes on PHP where using classes as arrays, by casting it into array.
