### PR TITLE
Fix update bug on configurable product

### DIFF
--- a/app/code/community/Bubble/Api/Helper/Catalog/Product.php
+++ b/app/code/community/Bubble/Api/Helper/Catalog/Product.php
@@ -25,13 +25,13 @@ class Bubble_Api_Helper_Catalog_Product extends Mage_Core_Helper_Abstract
 
             $usedProductIds = array_diff($newProductIds, $oldProductIds);
 
-            if (!empty($usedProductIds)) {
-                if ($product->isConfigurable()) {
-                    $this->_initConfigurableAttributesData($product, $usedProductIds, $priceChanges, $configurableAttributes);
-                } elseif ($product->isGrouped()) {
-                    $relations = array_fill_keys($usedProductIds, array('qty' => 0, 'position' => 0));
-                    $product->setGroupedLinkData($relations);
-                }
+            if (!empty($newProductIds) && $product->isConfigurable()) {
+                $this->_initConfigurableAttributesData($product, $newProductIds, $priceChanges, $configurableAttributes);
+            }
+            
+            if (!empty($usedProductIds) && $product->isGrouped()) {
+                $relations = array_fill_keys($usedProductIds, array('qty' => 0, 'position' => 0));
+                $product->setGroupedLinkData($relations);
             }
         }
 


### PR DESCRIPTION
The current code do an `array_diff` between old and new attributes and call a 'set' method. It seems to be a mistake.

For configurable products, we just need to set `newProductsIds` as associated products.
